### PR TITLE
Fix: Redirect user messages from stdout to stderr

### DIFF
--- a/src/utils/global-settings.ts
+++ b/src/utils/global-settings.ts
@@ -27,7 +27,7 @@ export class GlobalSettings {
     }
     // Normalize the base directory path
     this._allowedBaseDir = path.resolve(baseDir); 
-    console.log(`[GlobalSettings] Allowed base directory set to: ${this._allowedBaseDir}`);
+    console.error(`[GlobalSettings] Allowed base directory set to: ${this._allowedBaseDir}`);
   }
 
   /**


### PR DESCRIPTION
This PR fixes #4

## Issue
The MCP server is showing an error `Failed to parse message` when user messages are output to stdout instead of stderr. As shown in the logs, the messages sent to stdout are interfering with the JSON communication protocol:

```
2025-04-15 18:18:39.364 [warning] Failed to parse message: "[GlobalSettings] Allowed base directory set to: /Users/aromarious/xxxxxx/git-mcp-server\n"
```

The main issue is in `src/utils/global-settings.ts` where a console.log() statement is sending initialization messages to stdout, which should strictly be reserved for the JSON protocol messages.

## Changes
Changed console.log() to console.error() in src/utils/global-settings.ts:

```typescript
// Before
console.log(`[GlobalSettings] Allowed base directory set to: ${this._allowedBaseDir}`);

// After
console.error(`[GlobalSettings] Allowed base directory set to: ${this._allowedBaseDir}`);