### PR TITLE
fix: publish declared TypeScript declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "homepage": "https://github.com/cyanheads/git-mcp-server#readme",
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir ./dist --target node --external pino --external pino-pretty",
+    "build": "bun build ./src/index.ts --outdir ./dist --target node --external pino --external pino-pretty && bun run build:types",
+    "build:types": "bunx tsc -p tsconfig.build.json",
     "build:worker": "bun build ./src/worker.ts --outdir ./dist --target bun --no-external",
     "deploy:dev": "MCP_TRANSPORT_TYPE=http bunx wrangler dev",
     "deploy:prod": "MCP_TRANSPORT_TYPE=http bunx wrangler deploy",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "emitDeclarationOnly": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
+}


### PR DESCRIPTION
## Summary
- add a build-specific TypeScript config that emits declarations from `src`
- run declaration emit after the existing Bun JavaScript bundle step
- keep the declared `types` / `exports[.].types` path backed by a real `dist/index.d.ts`

## Why
The published `@cyanheads/git-mcp-server@2.15.1` package declares `dist/index.d.ts`, but the npm tarball only includes `dist/index.js`. `bun build` produces the bundled JavaScript entrypoint but does not emit TypeScript declaration files, so TypeScript consumers are pointed at a missing file.

Fixes #50.

## Validation
- `npm install --package-lock=false --ignore-scripts --no-audit --no-fund`
- `npx tsc -p tsconfig.build.json`
- verified `dist/index.d.ts` is generated
- package script assertion for `build` and `build:types`
- `git diff --check`

Note: Bun is not installed in this local environment, so I could not run the full `bun run build` end to end here. The new declaration-emission step itself was verified with the repo's TypeScript dependency via `npx tsc -p tsconfig.build.json`.